### PR TITLE
auto-populate URL from current page

### DIFF
--- a/Nib/index.js
+++ b/Nib/index.js
@@ -114,6 +114,9 @@ dropDownView.panel.port.on(CREATE_SOURCE, function(active_project_id, name){
   source_id = ss.storage.max_id;
   ss.storage.max_id = ss.storage.max_id + 1;
   var url = getURL();
+  if (url.startsWith('about:')) {
+    url = '';
+  }
   new_source = {
     "source_id": source_id,
     "name": name,


### PR DESCRIPTION
Almost trivial. I thought this would require a new event/response flow but I inject the URL when we create the source.

I believe that this should be the place where we hook in our scrapers to our sources. 

What do you guys think? Creating a source then has two parts:
1. Identify if we are on a supported page. If so, grab the info and pass it along.
2. Create the object with any passed-in values. Send it to the "source view" as we already do.

@jreinertson @ACalza @ChrisMckerracher
